### PR TITLE
Cosmetic manual improvements

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -6,7 +6,7 @@
 #' @param z complex vector
 #' @param relerr double, requested error
 #' @return complex vector
-#' @describeIn wrap compute w(z) = exp(-z^2) erfc(-iz)
+#' @describeIn wrap compute \eqn{w(z) = \exp(-z^2) \, \mathrm{erfc}(-iz)}{w(z) = exp(-z^2) erfc(-iz)}
 #' @family wrapper
 #' @examples
 #' Faddeeva_w(1:10 + 1i)
@@ -17,7 +17,7 @@ Faddeeva_w <- function(z, relerr = 0) {
 
 #' the scaled complementary error function
 #' @inheritParams Faddeeva_w
-#' @describeIn wrap compute erfcx(z) = exp(z^2) erfc(z)
+#' @describeIn wrap compute \eqn{\mathrm{erfcx}(z) = \exp(z^2) \, \mathrm{erfc}(z)}{erfcx(z) = exp(z^2) erfc(z)}
 #' @family wrapper
 #' @examples
 #' erfcx(1:10 + 1i)
@@ -28,7 +28,7 @@ erfcx <- function(z, relerr = 0) {
 
 #'  the error function of complex arguments
 #' @inheritParams Faddeeva_w
-#' @describeIn wrap compute erf(z)
+#' @describeIn wrap compute \eqn{\mathrm{erf}(z)}{erf(z)}
 #' @family wrapper
 #' @examples
 #' erf(1:10 + 1i)
@@ -39,7 +39,7 @@ erf <- function(z, relerr = 0) {
 
 #' the imaginary error function
 #' @inheritParams Faddeeva_w
-#' @describeIn wrap compute erfi(z) = -i erf(iz)
+#' @describeIn wrap compute \eqn{\mathrm{erfi}(z) = -i \, \mathrm{erf}(iz)}{erfi(z) = -i erf(iz)}
 #' @family wrapper
 #' @examples
 #' erfi(1:10 + 1i)
@@ -50,7 +50,7 @@ erfi <- function(z, relerr = 0) {
 
 #' the complementary error function
 #' @inheritParams Faddeeva_w
-#' @describeIn wrap compute erfc(z) = 1 - erf(z)
+#' @describeIn wrap compute \eqn{\mathrm{erfc}(z) = 1 - \mathrm{erf}(z)}{erfc(z) = 1 - erf(z)}
 #' @family wrapper
 #' @examples
 #' erfc(1:10 + 1i)
@@ -61,7 +61,7 @@ erfc <- function(z, relerr = 0) {
 
 #' the Dawson function
 #' @inheritParams Faddeeva_w
-#' @describeIn wrap compute Dawson(z) = sqrt(pi)/2  *  exp(-z^2) * erfi(z)
+#' @describeIn wrap compute \eqn{\mathrm{Dawson}(z) = \sqrt{\pi}/2 \exp(-z^2) \, \mathrm{erfi}(z)}{Dawson(z) = sqrt(pi)/2 * exp(-z^2) * erfi(z)}
 #' @family wrapper
 #' @examples
 #' Dawson(1:10 + 1i)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -16,7 +16,6 @@ Faddeeva_w <- function(z, relerr = 0) {
 }
 
 #' the scaled complementary error function
-#' @inheritParams Faddeeva_w
 #' @describeIn wrap compute \eqn{\mathrm{erfcx}(z) = \exp(z^2) \, \mathrm{erfc}(z)}{erfcx(z) = exp(z^2) erfc(z)}
 #' @family wrapper
 #' @examples
@@ -27,7 +26,6 @@ erfcx <- function(z, relerr = 0) {
 }
 
 #'  the error function of complex arguments
-#' @inheritParams Faddeeva_w
 #' @describeIn wrap compute \eqn{\mathrm{erf}(z)}{erf(z)}
 #' @family wrapper
 #' @examples
@@ -38,7 +36,6 @@ erf <- function(z, relerr = 0) {
 }
 
 #' the imaginary error function
-#' @inheritParams Faddeeva_w
 #' @describeIn wrap compute \eqn{\mathrm{erfi}(z) = -i \, \mathrm{erf}(iz)}{erfi(z) = -i erf(iz)}
 #' @family wrapper
 #' @examples
@@ -49,7 +46,6 @@ erfi <- function(z, relerr = 0) {
 }
 
 #' the complementary error function
-#' @inheritParams Faddeeva_w
 #' @describeIn wrap compute \eqn{\mathrm{erfc}(z) = 1 - \mathrm{erf}(z)}{erfc(z) = 1 - erf(z)}
 #' @family wrapper
 #' @examples
@@ -60,7 +56,6 @@ erfc <- function(z, relerr = 0) {
 }
 
 #' the Dawson function
-#' @inheritParams Faddeeva_w
 #' @describeIn wrap compute \eqn{\mathrm{Dawson}(z) = \sqrt{\pi}/2 \exp(-z^2) \, \mathrm{erfi}(z)}{Dawson(z) = sqrt(pi)/2 * exp(-z^2) * erfi(z)}
 #' @family wrapper
 #' @examples

--- a/R/Voigt.R
+++ b/R/Voigt.R
@@ -41,7 +41,6 @@ Voigt <- function(x, x0, sigma, gamma, real = TRUE, ...){
 ##' @description Lorentzian distribution
 ##' @title Lorentz
 ##' @describeIn Voigt Lorentzian lineshape function
-##' @inheritParams Voigt 
 ##' @export
 ##' @family helper_function
 Lorentz <- function(x, x0, gamma){
@@ -51,7 +50,6 @@ Lorentz <- function(x, x0, gamma){
 ##' @description Gaussian distribution
 ##' @title Gauss 
 ##' @describeIn Voigt Gaussian lineshape function
-##' @inheritParams Voigt
 ##' @importFrom stats dnorm
 ##' @export
 ##' @family helper_function

--- a/man/wrap.Rd
+++ b/man/wrap.Rd
@@ -34,17 +34,17 @@ the Faddeeva function
 }
 \section{Functions}{
 \itemize{
-\item \code{Faddeeva_w()}: compute w(z) = exp(-z^2) erfc(-iz)
+\item \code{Faddeeva_w()}: compute \eqn{w(z) = \exp(-z^2) \, \mathrm{erfc}(-iz)}{w(z) = exp(-z^2) erfc(-iz)}
 
-\item \code{erfcx()}: compute erfcx(z) = exp(z^2) erfc(z)
+\item \code{erfcx()}: compute \eqn{\mathrm{erfcx}(z) = \exp(z^2) \, \mathrm{erfc}(z)}{erfcx(z) = exp(z^2) erfc(z)}
 
-\item \code{erf()}: compute erf(z)
+\item \code{erf()}: compute \eqn{\mathrm{erf}(z)}{erf(z)}
 
-\item \code{erfi()}: compute erfi(z) = -i erf(iz)
+\item \code{erfi()}: compute \eqn{\mathrm{erfi}(z) = -i \, \mathrm{erf}(iz)}{erfi(z) = -i erf(iz)}
 
-\item \code{erfc()}: compute erfc(z) = 1 - erf(z)
+\item \code{erfc()}: compute \eqn{\mathrm{erfc}(z) = 1 - \mathrm{erf}(z)}{erfc(z) = 1 - erf(z)}
 
-\item \code{Dawson()}: compute Dawson(z) = sqrt(pi)/2  *  exp(-z^2) * erfi(z)
+\item \code{Dawson()}: compute \eqn{\mathrm{Dawson}(z) = \sqrt{\pi}/2 \exp(-z^2) \, \mathrm{erfi}(z)}{Dawson(z) = sqrt(pi)/2 * exp(-z^2) * erfi(z)}
 
 }}
 \examples{

--- a/src/callFaddeeva.cpp
+++ b/src/callFaddeeva.cpp
@@ -27,7 +27,6 @@ std::vector< std::complex<double> > Faddeeva_w(const std::vector< std::complex<d
 }
 
 //' the scaled complementary error function
-//' @inheritParams Faddeeva_w
 //' @describeIn wrap compute \eqn{\mathrm{erfcx}(z) = \exp(z^2) \, \mathrm{erfc}(z)}{erfcx(z) = exp(z^2) erfc(z)}
 //' @family wrapper
 //' @examples
@@ -44,7 +43,6 @@ std::vector< std::complex<double> > erfcx(const std::vector< std::complex<double
 }
 
 //'  the error function of complex arguments
-//' @inheritParams Faddeeva_w
 //' @describeIn wrap compute \eqn{\mathrm{erf}(z)}{erf(z)}
 //' @family wrapper
 //' @examples
@@ -61,7 +59,6 @@ std::vector< std::complex<double> > erf(const std::vector< std::complex<double> 
 }
 
 //' the imaginary error function
-//' @inheritParams Faddeeva_w
 //' @describeIn wrap compute \eqn{\mathrm{erfi}(z) = -i \, \mathrm{erf}(iz)}{erfi(z) = -i erf(iz)}
 //' @family wrapper
 //' @examples
@@ -78,7 +75,6 @@ std::vector< std::complex<double> > erfi(const std::vector< std::complex<double>
 }
 
 //' the complementary error function
-//' @inheritParams Faddeeva_w
 //' @describeIn wrap compute \eqn{\mathrm{erfc}(z) = 1 - \mathrm{erf}(z)}{erfc(z) = 1 - erf(z)}
 //' @family wrapper
 //' @examples
@@ -95,7 +91,6 @@ std::vector< std::complex<double> > erfc(const std::vector< std::complex<double>
 }
 
 //' the Dawson function
-//' @inheritParams Faddeeva_w
 //' @describeIn wrap compute \eqn{\mathrm{Dawson}(z) = \sqrt{\pi}/2 \exp(-z^2) \, \mathrm{erfi}(z)}{Dawson(z) = sqrt(pi)/2 * exp(-z^2) * erfi(z)}
 //' @family wrapper
 //' @examples

--- a/src/callFaddeeva.cpp
+++ b/src/callFaddeeva.cpp
@@ -11,7 +11,7 @@ using namespace Rcpp;
 //' @param z complex vector
 //' @param relerr double, requested error
 //' @return complex vector
-//' @describeIn wrap compute w(z) = exp(-z^2) erfc(-iz)
+//' @describeIn wrap compute \eqn{w(z) = \exp(-z^2) \, \mathrm{erfc}(-iz)}{w(z) = exp(-z^2) erfc(-iz)}
 //' @family wrapper
 //' @examples
 //' Faddeeva_w(1:10 + 1i)
@@ -28,7 +28,7 @@ std::vector< std::complex<double> > Faddeeva_w(const std::vector< std::complex<d
 
 //' the scaled complementary error function
 //' @inheritParams Faddeeva_w
-//' @describeIn wrap compute erfcx(z) = exp(z^2) erfc(z)
+//' @describeIn wrap compute \eqn{\mathrm{erfcx}(z) = \exp(z^2) \, \mathrm{erfc}(z)}{erfcx(z) = exp(z^2) erfc(z)}
 //' @family wrapper
 //' @examples
 //' erfcx(1:10 + 1i)
@@ -45,7 +45,7 @@ std::vector< std::complex<double> > erfcx(const std::vector< std::complex<double
 
 //'  the error function of complex arguments
 //' @inheritParams Faddeeva_w
-//' @describeIn wrap compute erf(z)
+//' @describeIn wrap compute \eqn{\mathrm{erf}(z)}{erf(z)}
 //' @family wrapper
 //' @examples
 //' erf(1:10 + 1i)
@@ -62,7 +62,7 @@ std::vector< std::complex<double> > erf(const std::vector< std::complex<double> 
 
 //' the imaginary error function
 //' @inheritParams Faddeeva_w
-//' @describeIn wrap compute erfi(z) = -i erf(iz)
+//' @describeIn wrap compute \eqn{\mathrm{erfi}(z) = -i \, \mathrm{erf}(iz)}{erfi(z) = -i erf(iz)}
 //' @family wrapper
 //' @examples
 //' erfi(1:10 + 1i)
@@ -79,7 +79,7 @@ std::vector< std::complex<double> > erfi(const std::vector< std::complex<double>
 
 //' the complementary error function
 //' @inheritParams Faddeeva_w
-//' @describeIn wrap compute erfc(z) = 1 - erf(z)
+//' @describeIn wrap compute \eqn{\mathrm{erfc}(z) = 1 - \mathrm{erf}(z)}{erfc(z) = 1 - erf(z)}
 //' @family wrapper
 //' @examples
 //' erfc(1:10 + 1i)
@@ -96,7 +96,7 @@ std::vector< std::complex<double> > erfc(const std::vector< std::complex<double>
 
 //' the Dawson function
 //' @inheritParams Faddeeva_w
-//' @describeIn wrap compute Dawson(z) = sqrt(pi)/2  *  exp(-z^2) * erfi(z)
+//' @describeIn wrap compute \eqn{\mathrm{Dawson}(z) = \sqrt{\pi}/2 \exp(-z^2) \, \mathrm{erfi}(z)}{Dawson(z) = sqrt(pi)/2 * exp(-z^2) * erfi(z)}
 //' @family wrapper
 //' @examples
 //' Dawson(1:10 + 1i)


### PR DESCRIPTION
This isn't necessary to pass R CMD check, but it is an improvement. I've marked up the equations in the documentation for LaTeX and HTML output. `roxygen2::roxygenise()` was complaining about the `@inheritParams` tag, so I removed it. This shouldn't conflict with #1 or #2 and can be merged in any order.