### PR TITLE
erfcx_y100: avoid undefined (int)NaN conversion

### DIFF
--- a/src/Faddeeva.cpp
+++ b/src/Faddeeva.cpp
@@ -1012,6 +1012,7 @@ cmplx FADDEEVA(w)(cmplx z, double relerr)
    compared to fitting the whole [0,1] interval with a single polynomial. */
 static double erfcx_y100(double y100)
 {
+  if (isnan(y100)) return NaN;
   switch ((int) y100) {
 case 0: {
 double t = 2*y100 - 1;


### PR DESCRIPTION
Sorry for somehow missing the other place where the code may perform an `(int)NaN` conversion.

This is definitely all of them because I cannot find any other place where the code would cast a floating-point number to an integer.