### PR TITLE
Switch http:// to https:// in README.{Rmd,md}

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![](http://www.r-pkg.org/badges/version/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
-[![](http://cranlogs.r-pkg.org/badges/grand-total/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
+[![](https://www.r-pkg.org/badges/version/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
+[![](https://cranlogs.r-pkg.org/badges/grand-total/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
 
 Wrapper to the [Faddeeva Package by Steven G.
 Johnson](http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package)

--- a/README.rmd
+++ b/README.rmd
@@ -15,8 +15,8 @@ knitr::opts_chunk$set(
 
 # RcppFaddeeva
 
-[![](http://www.r-pkg.org/badges/version/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
-[![](http://cranlogs.r-pkg.org/badges/grand-total/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
+[![](https://www.r-pkg.org/badges/version/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
+[![](https://cranlogs.r-pkg.org/badges/grand-total/RcppFaddeeva)](https://CRAN.R-project.org/package=RcppFaddeeva)
 
 Wrapper to the
 [Faddeeva Package by Steven G. Johnson](http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package)


### PR DESCRIPTION
Salut @baptiste minor maintenance commit here -- I noticed that in (some, old) README.md of mine old badges still using http:// were not rendering, and that was also the case in the old RcppFaddeeva checkout I had.  As it seemed to be the same problem 'upstream' here (you have the two lines, yet the previewed README.md in the browser showed nothing) I made a quick PR.  

Feel free to ignore or alter -- as the package is no longer on CRAN the CRAN badge is redundant. (You may want to try a reupload, the fix you added by @aitap is as usual spot-on and promising.)