### PR TITLE
Fix for error from -Werror=format-security

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,4 @@ URL: https://github.com/nano-optics/RcppFaddeeva
 BugReports: https://github.com/nano-optics/RcppFaddeeva/issues
 LinkingTo: Rcpp
 NeedsCompilation: yes
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/RcppFaddeeva-package.r
+++ b/R/RcppFaddeeva-package.r
@@ -2,7 +2,6 @@
 ##'
 ##' Access to a family of Gauss error functions for arbitrary complex arguments is provided via the 'Faddeeva' package by Steven G. Johnson (see <http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package> for more information).
 ##' @name RcppFaddeeva-package
-##' @docType package
 ##' @useDynLib RcppFaddeeva
 ##' @importFrom Rcpp evalCpp
 ##' @title RcppFaddeeva
@@ -11,4 +10,4 @@
 ##' \url{http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package}
 ##' @keywords packagelibrary
 ##' 
-NULL
+"_PACKAGE"

--- a/man/RcppFaddeeva-package.Rd
+++ b/man/RcppFaddeeva-package.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/RcppFaddeeva-package.r
 \docType{package}
 \name{RcppFaddeeva-package}
+\alias{RcppFaddeeva}
 \alias{RcppFaddeeva-package}
 \title{RcppFaddeeva}
 \description{
@@ -13,5 +14,29 @@ Access to a family of Gauss error functions for arbitrary complex arguments is p
 \references{
 The Faddeeva Package wiki page details the algorithms implemented by Steve G. Johnson, 
 \url{http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package}
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/nano-optics/RcppFaddeeva}
+  \item Report bugs at \url{https://github.com/nano-optics/RcppFaddeeva/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Baptiste Auguié \email{baptiste.auguie@vuw.ac.nz}
+
+Authors:
+\itemize{
+  \item Dirk Eddelbuettel \email{edd@debian.org}
+  \item Steven G. Johnson (Author of Faddeeva) [copyright holder]
+}
+
+Other contributors:
+\itemize{
+  \item Dennis Feehan [contributor]
+  \item Ivan Krylov [contributor]
+}
+
 }
 \keyword{packagelibrary}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -43,7 +43,7 @@ RcppExport SEXP _RcppFaddeeva_Faddeeva_w(SEXP zSEXP, SEXP relerrSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -78,7 +78,7 @@ RcppExport SEXP _RcppFaddeeva_erfcx(SEXP zSEXP, SEXP relerrSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -113,7 +113,7 @@ RcppExport SEXP _RcppFaddeeva_erf(SEXP zSEXP, SEXP relerrSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -148,7 +148,7 @@ RcppExport SEXP _RcppFaddeeva_erfi(SEXP zSEXP, SEXP relerrSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -183,7 +183,7 @@ RcppExport SEXP _RcppFaddeeva_erfc(SEXP zSEXP, SEXP relerrSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -218,7 +218,7 @@ RcppExport SEXP _RcppFaddeeva_Dawson(SEXP zSEXP, SEXP relerrSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;


### PR DESCRIPTION
Currently, trying to install the package with devtools gives many errors like:
```
RcppExports.cpp: In function ‘SEXPREC* _RcppFaddeeva_Faddeeva_w(SEXP, SEXP)’:
RcppExports.cpp:46:17: error: format not a string literal and no format arguments [-Werror=format-security]
   46 |         Rf_error(CHAR(rcpp_msgSEXP_gen));
      |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```

I ran devtools::document() to rerun compileAttributes(), which updated RcppExports.cpp to fix this issue.

Also, I added a fix to RcppFaddeeva-package.r for the additional following issue that appeared when running devtools::document():
```
RcppFaddeeva-package.r:14: `@docType "package"` is deprecated. Please document "_PACKAGE" instead.
```

Also -- would this fix be enough to get the package back onto CRAN?